### PR TITLE
Migrated to use stable version of Riverpod

### DIFF
--- a/lib/src/feature_state/feature_state_provider.dart
+++ b/lib/src/feature_state/feature_state_provider.dart
@@ -17,7 +17,7 @@ import 'feature.dart';
 /// the mapper and obtain the states that way.
 class FeatureStateProvider<S, F extends FeatureMapper<S>> {
   final StateNotifierProvider<F, Map<Feature, S>> _provider;
-  final F Function(ProviderRefBase) create;
+  final F Function(Ref) create;
 
   FeatureStateProvider(this.create)
       : _provider = StateNotifierProvider<F, Map<Feature, S>>(create);

--- a/lib/src/feature_state/feature_widget.dart
+++ b/lib/src/feature_state/feature_widget.dart
@@ -55,9 +55,7 @@ class _FeatureWidgetState<S> extends ConsumerState<FeatureWidget<S>> {
     final currentState = mapper.getStateFor(widget.feature);
 
     //TODO THIS SHOULDN'T BE NEEDED, FIGURE OUT WHY THE REBUILD DOESN'T HAPPEN
-    ref.listen(widget.provider(), (map) {
-      setState(() {});
-    });
+    ref.listen(widget.provider(), (_, __) => setState(() {}));
 
     return widget.builder(context, currentState);
   }

--- a/lib/src/providers/external_interface_provider.dart
+++ b/lib/src/providers/external_interface_provider.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class ExternalInterfaceProvider<I extends ExternalInterface>
     implements OverridableProvider<I> {
   final Provider<I> _provider;
-  final I Function(ProviderRefBase) create;
+  final I Function(Ref) create;
 
   ExternalInterfaceProvider(this.create) : _provider = Provider<I>(create);
 

--- a/lib/src/providers/gateway_provider.dart
+++ b/lib/src/providers/gateway_provider.dart
@@ -6,7 +6,7 @@ import 'gateway.dart';
 
 class GatewayProvider<G extends Gateway> implements OverridableProvider<G> {
   final Provider<G> _provider;
-  final G Function(ProviderRefBase) create;
+  final G Function(Ref) create;
 
   GatewayProvider(this.create) : _provider = Provider<G>(create);
 

--- a/lib/src/providers/use_case_provider.dart
+++ b/lib/src/providers/use_case_provider.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class UseCaseProvider<E extends Entity, U extends UseCase<E>>
     implements OverridableProvider<U> {
   final StateNotifierProvider<U, E> _provider;
-  final U Function(ProviderRefBase) create;
+  final U Function(Ref) create;
 
   UseCaseProvider(this.create)
       : _provider = StateNotifierProvider<U, E>(create);

--- a/lib/src/tests/test_helpers.dart
+++ b/lib/src/tests/test_helpers.dart
@@ -74,7 +74,7 @@ void uiTest(
 void useCaseTest<U extends UseCase, O extends Output>(
   String description, {
   required ProvidersContext context,
-  required U Function(ProviderRefBase) build,
+  required U Function(Ref) build,
   required FutureOr<void> Function(U) execute,
   FutureOr<void> Function(UseCaseProvider)? setup,
   Iterable Function()? expect,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,17 +16,17 @@ dependencies:
   flutter_test:
     sdk: flutter
 
-  riverpod: ^1.0.0-dev.10
-  flutter_riverpod: ^1.0.0-dev.10
+  riverpod: ^1.0.0
+  flutter_riverpod: ^1.0.0
   equatable: ^2.0.3
   http: ^0.13.4
   meta: ^1.7.0
-  either_dart: ^0.1.3
-  go_router: ^2.2.0
+  either_dart: ^0.1.4
+  go_router: ^2.2.4
 
   # For default implementations:
   graphql: ^5.0.0
-  cloud_firestore: ^2.5.4
+  cloud_firestore: ^3.1.0
 
 
 dev_dependencies:


### PR DESCRIPTION
The stable version of `riverpod` has a **breaking change**: `ProviderRefBase` class has been renamed into `Ref`

_since we're using ^1.0.0-dev.10 in our pubspec, the version auto upgraded to `1.0.0`._