### PR TITLE
feat(defaults): Make the `id` property optional in `FirebaseWriteRequest`

### DIFF
--- a/lib/src/defaults/providers/firebase/firebase_requests.dart
+++ b/lib/src/defaults/providers/firebase/firebase_requests.dart
@@ -29,8 +29,8 @@ class FirebaseReadIdRequest extends FirebaseRequest {
 }
 
 class FirebaseWriteRequest extends FirebaseRequest {
-  final String id;
-  FirebaseWriteRequest({required String path, required this.id})
+  final String? id;
+  FirebaseWriteRequest({required String path, this.id})
       : super(path: path);
 }
 


### PR DESCRIPTION
Thanks for this awesome framework! ❤️

This PR makes the `id` property optional in `FirebaseWriteRequest` as it isn't needed to perform the request.

## Details

### Context
`FirebaseWriteRequest` object is used by `FirebaseExternalInterface`:

```
void _withFirebaseWriteRequest(
  FirebaseWriteRequest request,
  ResponseSender<FirebaseSuccessResponse> send,
) async {
  final id = await _client.write(
    path: request.path,
    id: request.id,
    content: request.toJson(),
  );
  if (id.isEmpty) {
    sendError(FirebaseFailureResponse(type: FirebaseFailureType.noContent));
  } else {
    send(FirebaseSuccessResponse({'id': id}));
  }
}
 ``` 

to call the following `FirebaseClient` function:

```
/// Writes using firestore collection or document depending upon the [path].
///
/// If [id] is provided, a document with the provided id will be created.
/// Otherwise, an auto-generated id will be provided.
Future<String> write({
  required String path,
  required Map<String, dynamic> content,
  String? id,
  BatchKey? batchKey,
}) async
```

to write a new document in Firestore.

### Problem
The `FirebaseClient` function  mentioned above accepts an optional `id` parameter, however, an `id` parameter is required to create  a `FirebaseWriteRequest` object::
```
class FirebaseWriteRequest extends FirebaseRequest {
  final String id;
  FirebaseWriteRequest({required String path, required this.id})
      : super(path: path);
}
```
This means that a document id will need to be generated in the frontend even though it's not required in order to perform the request.

### Proposed solution
Make the `id` property optional in `FirebaseWriteRequest`.